### PR TITLE
Add image generation pages and shared components

### DIFF
--- a/frontend/components/ImageCard.tsx
+++ b/frontend/components/ImageCard.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface ImageCardProps {
+  src: string;
+  alt?: string;
+}
+
+const ImageCard: React.FC<ImageCardProps> = ({ src, alt }) => (
+  <div className="image-card">
+    <img src={src} alt={alt || 'generated'} />
+  </div>
+);
+
+export default ImageCard;

--- a/frontend/components/RequestForm.tsx
+++ b/frontend/components/RequestForm.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+interface RequestFormProps {
+  onSubmit: (prompt: string) => void;
+}
+
+const RequestForm: React.FC<RequestFormProps> = ({ onSubmit }) => {
+  const [prompt, setPrompt] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(prompt);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="text"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Введите текст"
+      />
+      <button type="submit">Создать</button>
+    </form>
+  );
+};
+
+export default RequestForm;

--- a/frontend/pages/gallery.tsx
+++ b/frontend/pages/gallery.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import ImageCard from '../components/ImageCard';
+
+const GalleryPage: React.FC = () => {
+  const [images, setImages] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem('images') || '[]');
+    setImages(stored);
+  }, []);
+
+  return (
+    <div>
+      {images.map((src, idx) => (
+        <ImageCard key={idx} src={src} />
+      ))}
+    </div>
+  );
+};
+
+export default GalleryPage;

--- a/frontend/pages/generate.tsx
+++ b/frontend/pages/generate.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import RequestForm from '../components/RequestForm';
+import ImageCard from '../components/ImageCard';
+
+const GeneratePage: React.FC = () => {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  const handleGenerate = async (prompt: string) => {
+    try {
+      const response = await fetch('/generate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prompt }),
+      });
+      const data = await response.json();
+      if (data.url) {
+        setImageUrl(data.url);
+        const stored = JSON.parse(localStorage.getItem('images') || '[]');
+        localStorage.setItem('images', JSON.stringify([data.url, ...stored]));
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div>
+      <RequestForm onSubmit={handleGenerate} />
+      {imageUrl && <ImageCard src={imageUrl} />}
+    </div>
+  );
+};
+
+export default GeneratePage;


### PR DESCRIPTION
## Summary
- add generate page that posts prompts to `/generate` and displays the resulting image
- add gallery page to display previously generated images
- extract reusable `RequestForm` and `ImageCard` components

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd39e139c883238ee90cea06c236a1