### PR TITLE
Add basic JWT auth and protected frontend pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+app.db

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta
+import hashlib
+from fastapi import APIRouter, Depends, HTTPException
+from jose import jwt
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal
+from .models import User
+
+SECRET_KEY = "supersecret"
+ALGORITHM = "HS256"
+
+router = APIRouter()
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+
+class UserLogin(BaseModel):
+    username: str
+    password: str
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_token(username: str):
+    expire = datetime.utcnow() + timedelta(hours=1)
+    to_encode = {"sub": username, "exp": expire}
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+@router.post("/register")
+async def register(user: UserCreate, db: Session = Depends(get_db)):
+    existing = db.query(User).filter(User.username == user.username).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed = hashlib.sha256(user.password.encode()).hexdigest()
+    db_user = User(username=user.username, password_hash=hashed)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    token = create_token(db_user.username)
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/login")
+async def login(user: UserLogin, db: Session = Depends(get_db)):
+    db_user = db.query(User).filter(User.username == user.username).first()
+    if not db_user:
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    hashed = hashlib.sha256(user.password.encode()).hexdigest()
+    if hashed != db_user.password_hash:
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    token = create_token(db_user.username)
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = 'sqlite:///./app.db'
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+from .auth import router as auth_router
+from .database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+app.include_router(auth_router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+python-jose
+pydantic

--- a/frontend/pages/gallery.tsx
+++ b/frontend/pages/gallery.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Gallery() {
+  const router = useRouter();
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.replace('/login');
+    }
+  }, []);
+
+  return <div>Gallery page</div>;
+}

--- a/frontend/pages/generate.tsx
+++ b/frontend/pages/generate.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Generate() {
+  const router = useRouter();
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.replace('/login');
+    }
+  }, []);
+
+  return <div>Generate page</div>;
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,0 +1,28 @@
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:8000/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    localStorage.setItem('token', data.access_token);
+    router.push('/generate');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -1,0 +1,28 @@
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Register() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:8000/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    localStorage.setItem('token', data.access_token);
+    router.push('/generate');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add FastAPI auth endpoints issuing JWT
- hook up SQLite with SQLAlchemy user model
- add login/register pages storing token and guard generate/gallery routes

## Testing
- `python -m py_compile backend/app/*.py`
- `cd frontend && npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68bd3ae0e4c08323a41c16aeed22cada