### PR TITLE
Add Redis job queue and frontend polling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+import redis
+from rq import Queue
+from rq.job import Job
+
+from .tasks import process_prompt
+
+app = FastAPI()
+
+# Redis connection and RQ queue
+redis_conn = redis.Redis(host="localhost", port=6379, db=0)
+queue = Queue("default", connection=redis_conn)
+
+# Serve frontend static files
+frontend_path = Path(__file__).resolve().parents[2] / "frontend"
+app.mount("/", StaticFiles(directory=frontend_path, html=True), name="frontend")
+
+
+class PromptRequest(BaseModel):
+    prompt: str
+
+
+@app.post("/generate")
+def generate(req: PromptRequest):
+    """Enqueue a job and return its ID."""
+    job = queue.enqueue(process_prompt, req.prompt)
+    return {"job_id": job.get_id()}
+
+
+@app.get("/status/{job_id}")
+def job_status(job_id: str):
+    """Return job status and result if finished."""
+    try:
+        job = Job.fetch(job_id, connection=redis_conn)
+    except Exception:
+        return {"status": "not_found", "result": None}
+    return {"status": job.get_status(), "result": job.result}

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,6 @@
+import time
+
+def process_prompt(prompt: str) -> str:
+    """Simulate a long-running task by sleeping and returning a result."""
+    time.sleep(5)
+    return prompt.upper()

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,0 +1,12 @@
+import os
+import redis
+from rq import Worker, Queue, Connection
+
+listen = ['default']
+redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+conn = redis.from_url(redis_url)
+
+if __name__ == '__main__':
+    with Connection(conn):
+        worker = Worker(map(Queue, listen))
+        worker.work()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+redis
+rq

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Prompt Generator</title>
+</head>
+<body>
+    <h1>Prompt Generator</h1>
+    <textarea id="prompt" rows="4" cols="50" placeholder="Enter prompt..."></textarea><br />
+    <button id="send">Send</button>
+    <div id="status"></div>
+    <script>
+    const sendBtn = document.getElementById('send');
+    const statusDiv = document.getElementById('status');
+
+    sendBtn.addEventListener('click', async () => {
+        const prompt = document.getElementById('prompt').value;
+        const response = await fetch('/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt })
+        });
+        const data = await response.json();
+        const jobId = data.job_id;
+        statusDiv.textContent = 'Job queued: ' + jobId;
+
+        const interval = setInterval(async () => {
+            const res = await fetch(`/status/${jobId}`);
+            const info = await res.json();
+            statusDiv.textContent = `Status: ${info.status}`;
+            if (info.result) {
+                statusDiv.textContent = `Result: ${info.result}`;
+                clearInterval(interval);
+            }
+        }, 1000);
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- connect FastAPI backend to Redis using RQ
- queue POST /generate tasks and expose GET /status/{job_id}
- add simple frontend that polls job status

## Testing
- `pip install -r backend/requirements.txt`
- `python -m py_compile backend/app/main.py backend/app/tasks.py backend/app/worker.py`
- `redis-server --version`


------
https://chatgpt.com/codex/tasks/task_b_68bd40ac2ab48323a53a93d68f3beb18