### PR TITLE
Add gallery search and style filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+node_modules/
+.DS_Store

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,45 @@
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models import Base, Gallery
+
+DATABASE_URL = "sqlite:///./gallery.db"
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# create tables
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/gallery", response_model=List[dict])
+def get_gallery(
+    q: Optional[str] = None,
+    style: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """Return gallery items with optional search and style filter."""
+    query = db.query(Gallery)
+    if q:
+        query = query.filter(Gallery.prompt.contains(q))
+    if style:
+        query = query.filter(Gallery.style == style)
+    items = query.all()
+    return [
+        {"id": item.id, "prompt": item.prompt, "style": item.style}
+        for item in items
+    ]

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, String, Index
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class Gallery(Base):
+    """Simple gallery item model."""
+
+    __tablename__ = "gallery"
+
+    id = Column(Integer, primary_key=True)
+    prompt = Column(String, nullable=False)
+    style = Column(String, nullable=True)
+
+    # explicit indexes to speed up text search and style filtering
+    __table_args__ = (
+        Index("ix_gallery_prompt", "prompt"),
+        Index("ix_gallery_style", "style"),
+    )

--- a/frontend/pages/gallery.tsx
+++ b/frontend/pages/gallery.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+interface GalleryItem {
+  id: number;
+  prompt: string;
+  style: string;
+}
+
+const GalleryPage = () => {
+  const [q, setQ] = useState('');
+  const [style, setStyle] = useState('');
+  const [items, setItems] = useState<GalleryItem[]>([]);
+
+  const load = () => {
+    const params = new URLSearchParams();
+    if (q) params.append('q', q);
+    if (style) params.append('style', style);
+    fetch(`/gallery?${params.toString()}`)
+      .then((res) => res.json())
+      .then((data) => setItems(data));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Search..."
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <select value={style} onChange={(e) => setStyle(e.target.value)}>
+          <option value="">All styles</option>
+          <option value="realistic">Realistic</option>
+          <option value="abstract">Abstract</option>
+        </select>
+        <button onClick={load}>Apply</button>
+      </div>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.prompt} ({item.style})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default GalleryPage;


### PR DESCRIPTION
## Summary
- extend `/gallery` endpoint with text and style filters
- add SQL indexes for prompt and style fields
- implement gallery page with search and style filter UI
- add gitignore for common artifacts

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd50404d9c83239f63673ff828d4d4