### PR TITLE
feat: add notification infrastructure

### DIFF
--- a/backend/app/generate.py
+++ b/backend/app/generate.py
@@ -1,0 +1,29 @@
+"""Stub generation module that notifies users when done."""
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .notifications import send_email, send_web_push
+
+
+@dataclass
+class User:
+    id: int
+    email: Optional[str] = None
+    push_subscription: Optional[dict] = None
+
+
+users: Dict[int, User] = {}
+
+
+async def generate(user_id: int) -> str:
+    """Pretend to generate some data for a user and notify them."""
+    result = "generated data"
+
+    user = users.get(user_id)
+    if user:
+        if user.email:
+            await send_email(user.email, "Generation complete", "Your content is ready.")
+        if user.push_subscription:
+            send_web_push(user.push_subscription, "Generation complete")
+
+    return result

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,27 @@
+import aiosmtplib
+from email.message import EmailMessage
+from pywebpush import webpush, WebPushException
+
+
+async def send_email(to_address: str, subject: str, body: str) -> None:
+    """Send an email using aiosmtplib."""
+    message = EmailMessage()
+    message["From"] = "no-reply@example.com"
+    message["To"] = to_address
+    message["Subject"] = subject
+    message.set_content(body)
+
+    await aiosmtplib.send(message, hostname="localhost", port=1025)
+
+
+def send_web_push(subscription_info: dict, data: str) -> None:
+    """Send a web push notification using pywebpush."""
+    try:
+        webpush(
+            subscription_info=subscription_info,
+            data=data,
+            vapid_private_key="test_private_key",
+            vapid_claims={"sub": "mailto:admin@example.com"},
+        )
+    except WebPushException as exc:  # pragma: no cover - logging stub
+        print(f"Web push failed: {exc}")

--- a/frontend/hooks/useNotifications.ts
+++ b/frontend/hooks/useNotifications.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+export function useNotifications(enabled: boolean) {
+  const [subscription, setSubscription] = useState<PushSubscription | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+      return;
+    }
+
+    async function register() {
+      const reg = await navigator.serviceWorker.register("/sw.js");
+      let sub = await reg.pushManager.getSubscription();
+      if (!sub) {
+        sub = await reg.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: "PUBLIC_KEY_PLACEHOLDER",
+        });
+      }
+      setSubscription(sub);
+      // TODO: send subscription to backend for storage
+    }
+
+    register();
+  }, [enabled]);
+
+  return subscription;
+}

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from "react";
+import { useNotifications } from "../hooks/useNotifications";
+
+export default function Profile() {
+  const [enabled, setEnabled] = useState(false);
+  const subscription = useNotifications(enabled);
+
+  return (
+    <div>
+      <h1>Profile</h1>
+      <label>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+        />
+        Enable notifications
+      </label>
+      {subscription && <p>Notifications active</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add notification utilities for email and web push
- trigger notifications when generation completes
- allow users to enable push notifications in profile page

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd53482e088323b13077fb2ea0dc8d