### PR TITLE
feat: add API key management

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+from fastapi import Depends, HTTPException, Security
+from fastapi.security import APIKeyHeader
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models import ApiKey, Base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def verify_api_key(
+    api_key: str = Security(api_key_header), db: Session = Depends(get_db)
+) -> ApiKey:
+    """Dependency that ensures the provided API key exists."""
+    if not api_key:
+        raise HTTPException(status_code=403, detail="API key required")
+
+    key_obj = db.query(ApiKey).filter(ApiKey.key == api_key).first()
+    if not key_obj:
+        raise HTTPException(status_code=403, detail="Invalid API key")
+
+    key_obj.last_used = datetime.utcnow()
+    db.commit()
+    return key_obj

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,41 @@
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from .models import ApiKey
+from .dependencies import get_db
+
+app = FastAPI()
+
+
+class ApiKeyRequest(BaseModel):
+    action: str
+
+
+def get_current_user(authorization: str = Header(...)):
+    if authorization != "Bearer secret":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return {"id": 1}
+
+
+@app.post("/api-keys")
+def api_keys_endpoint(
+    payload: ApiKeyRequest,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """Create or delete API keys for the current user."""
+    if payload.action == "create":
+        new_key = ApiKey.generate()
+        key_obj = ApiKey(key=new_key, user_id=current_user["id"])
+        db.add(key_obj)
+        db.commit()
+        db.refresh(key_obj)
+        return {"key": new_key}
+
+    if payload.action == "delete":
+        db.query(ApiKey).filter(ApiKey.user_id == current_user["id"]).delete()
+        db.commit()
+        return {"deleted": True}
+
+    raise HTTPException(status_code=400, detail="Invalid action")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+import secrets
+
+from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+
+    key = Column(String, primary_key=True, index=True)
+    user_id = Column(Integer, index=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    last_used = Column(DateTime, nullable=True)
+
+    @staticmethod
+    def generate() -> str:
+        """Generate a random API key."""
+        return secrets.token_hex(32)

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+export default function Profile() {
+  const [apiKey, setApiKey] = useState<string | null>(null);
+
+  const request = async (action: "create" | "delete") => {
+    const res = await fetch("/api-keys", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer secret",
+      },
+      body: JSON.stringify({ action }),
+    });
+    return res.json();
+  };
+
+  const handleCreate = async () => {
+    const data = await request("create");
+    setApiKey(data.key);
+  };
+
+  const handleDelete = async () => {
+    await request("delete");
+    setApiKey(null);
+  };
+
+  return (
+    <div>
+      <h1>API Keys</h1>
+      {apiKey && <p>Your key: {apiKey}</p>}
+      <button onClick={handleCreate}>Создать</button>
+      <button onClick={handleDelete}>Удалить</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SQLAlchemy model for API keys
- add endpoint and dependency to manage API keys
- add profile page section to create/delete API keys

## Testing
- `pytest`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_68bd57e2383483238ac4ef136bbfff2a