### PR TITLE
feat: add image tagging and CLIP search

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./gallery.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/embeddings.py
+++ b/backend/app/embeddings.py
@@ -1,0 +1,30 @@
+from functools import lru_cache
+from typing import List
+
+import torch
+from PIL import Image
+from transformers import CLIPModel, CLIPProcessor
+
+
+@lru_cache()
+def _load_model():
+    model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
+    processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+    return model, processor
+
+def image_embedding(path: str) -> List[float]:
+    model, processor = _load_model()
+    image = Image.open(path)
+    inputs = processor(images=image, return_tensors="pt")
+    with torch.no_grad():
+        embedding = model.get_image_features(**inputs)
+    embedding = embedding / embedding.norm(p=2, dim=-1, keepdim=True)
+    return embedding[0].cpu().tolist()
+
+def text_embedding(text: str) -> List[float]:
+    model, processor = _load_model()
+    inputs = processor(text=[text], return_tensors="pt", padding=True)
+    with torch.no_grad():
+        embedding = model.get_text_features(**inputs)
+    embedding = embedding / embedding.norm(p=2, dim=-1, keepdim=True)
+    return embedding[0].cpu().tolist()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from fastapi import Depends, FastAPI, Query
+from sqlalchemy.orm import Session
+
+from . import embeddings, models
+from .database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.get("/gallery")
+def get_gallery(q: str | None = Query(default=None), db: Session = Depends(get_db)):
+    images: List[models.Image] = db.query(models.Image).all()
+    if q:
+        query_emb = embeddings.text_embedding(q)
+        images.sort(
+            key=lambda im: cosine_similarity(query_emb, im.embedding),
+            reverse=True,
+        )
+    return [
+        {
+            "id": im.id,
+            "path": im.path,
+            "tags": [t.name for t in im.tags],
+        }
+        for im in images
+    ]
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    if not a or not b:
+        return 0.0
+    import math
+
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, String, Table, ForeignKey, PickleType
+from sqlalchemy.orm import relationship, declarative_base
+
+Base = declarative_base()
+
+image_tags = Table(
+    "image_tags",
+    Base.metadata,
+    Column("image_id", ForeignKey("images.id"), primary_key=True),
+    Column("tag_id", ForeignKey("tags.id"), primary_key=True),
+)
+
+class Image(Base):
+    __tablename__ = "images"
+
+    id = Column(Integer, primary_key=True)
+    path = Column(String, unique=True, nullable=False)
+    embedding = Column(PickleType)
+
+    tags = relationship("Tag", secondary=image_tags, back_populates="images")
+
+class Tag(Base):
+    __tablename__ = "tags"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+
+    images = relationship("Image", secondary=image_tags, back_populates="tags")

--- a/frontend/pages/gallery.tsx
+++ b/frontend/pages/gallery.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+interface ImageItem {
+  id: number;
+  path: string;
+  tags: string[];
+}
+
+export default function Gallery() {
+  const [tags, setTags] = useState("");
+  const [query, setQuery] = useState("");
+  const [images, setImages] = useState<ImageItem[]>([]);
+
+  const load = async () => {
+    const params = new URLSearchParams();
+    if (tags) params.append("tags", tags);
+    if (query) params.append("q", query);
+    const res = await fetch(`/gallery?${params.toString()}`);
+    const data = await res.json();
+    setImages(data);
+  };
+
+  return (
+    <div>
+      <input
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        placeholder="tags"
+      />
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="search by meaning"
+      />
+      <button onClick={load}>Search</button>
+      <div>
+        {images.map((img) => (
+          <div key={img.id}>
+            <img src={img.path} alt="" />
+            <div>{img.tags.join(", ")}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for images, tags and their association
- compute image/text embeddings via CLIP
- support semantic `q` filtering for `/gallery`
- expose gallery page with tag input and semantic search

## Testing
- `python -m py_compile backend/app/*.py`
- `npx tsc frontend/pages/gallery.tsx --noEmit --jsx react --lib ESNext,DOM` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_b_68bd57e5aba08323b9a5fe342bfc13b4